### PR TITLE
Add static HTML/CSS/JS versions of key app screens

### DIFF
--- a/static-site/assets/logo.svg
+++ b/static-site/assets/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#0ea5e9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M11 2v2" />
+  <path d="M5 2v2" />
+  <path d="M5 3H4a2 2 0 0 0-2 2v4a6 6 0 0 0 12 0V5a2 2 0 0 0-2-2h-1" />
+  <path d="M8 15a6 6 0 0 0 12 0v-3" />
+  <circle cx="20" cy="10" r="2" />
+  <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z" fill="#ef4444" stroke="#ef4444" />
+</svg>

--- a/static-site/condition.html
+++ b/static-site/condition.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Condition Results - GeneticsCare AI</title>
+  <link rel="stylesheet" href="css/app.css" />
+</head>
+<body data-page="condition">
+  <header>
+    <div class="header-content">
+      <a href="index.html" class="logo"><img src="assets/logo.svg" alt="GeneticsCare AI logo" />GeneticsCare AI</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="condition.html">Condition</a>
+        <a href="qa.html">Q&amp;A</a>
+        <a href="login.html">Login</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container">
+    <section class="card">
+      <h2 id="condition-name">Condition Name</h2>
+      <p id="gene-variant" class="badge"></p>
+      <p><strong id="classification"></strong></p>
+      <p id="description"></p>
+      <h3>What This Means for Your Health</h3>
+      <ul id="implications"></ul>
+      <h3>Recommended Next Steps</h3>
+      <ul id="recommendations"></ul>
+      <h3>Educational Resources</h3>
+      <ul id="resources"></ul>
+      <div class="actions">
+        <button id="go-to-qa" class="btn primary">Ask Questions &amp; Get Support</button>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <div class="container">
+      <p>&copy; 2024 GeneticsCare AI</p>
+      <span class="disclaimer">This AI tool is not a doctor or nurse. Information provided should be discussed with qualified healthcare professionals.</span>
+    </div>
+  </footer>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/static-site/css/app.css
+++ b/static-site/css/app.css
@@ -1,0 +1,191 @@
+:root {
+  --primary: #0ea5e9;
+  --primary-dark: #0284c7;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background: linear-gradient(135deg, #f0f9ff, #ffffff);
+  color: #333;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+header {
+  background: #fff;
+  border-bottom: 1px solid #e5e7eb;
+}
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  max-width: 960px;
+  margin: 0 auto;
+}
+.logo {
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  color: #111;
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+.logo img {
+  height: 32px;
+  margin-right: 0.5rem;
+}
+nav a {
+  margin-left: 1rem;
+  text-decoration: none;
+  color: #333;
+}
+nav a:hover {
+  color: var(--primary);
+}
+.container {
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1rem;
+  flex: 1;
+}
+.narrow {
+  max-width: 400px;
+}
+.card {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  margin-bottom: 1.5rem;
+}
+.btn {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  text-decoration: none;
+}
+.btn.primary {
+  background: var(--primary);
+  color: #fff;
+}
+.btn.primary:hover {
+  background: var(--primary-dark);
+}
+.btn.outline {
+  background: #fff;
+  border: 1px solid var(--primary);
+  color: var(--primary);
+}
+.btn.outline:hover {
+  background: var(--primary);
+  color: #fff;
+}
+.link {
+  background: none;
+  border: none;
+  color: var(--primary);
+  cursor: pointer;
+  text-decoration: underline;
+}
+input[type="text"],
+input[type="email"],
+input[type="password"] {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+}
+label {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-weight: 500;
+}
+footer {
+  background: #fff;
+  border-top: 1px solid #e5e7eb;
+}
+footer .container {
+  text-align: center;
+  font-size: 0.875rem;
+  color: #6b7280;
+  padding: 1rem;
+}
+footer .disclaimer {
+  display: block;
+  margin-top: 0.5rem;
+  color: #9ca3af;
+}
+.hero {
+  text-align: center;
+  padding: 4rem 1rem;
+}
+.hero h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+.hero p {
+  font-size: 1.125rem;
+  margin-bottom: 2rem;
+}
+.card .actions {
+  text-align: center;
+  margin-top: 1.5rem;
+}
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  background: #f3f4f6;
+  font-size: 0.875rem;
+}
+.chat-card {
+  display: flex;
+  flex-direction: column;
+  height: 600px;
+}
+.chat-area {
+  flex: 1;
+  overflow-y: auto;
+  border: 1px solid #e5e7eb;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  background: #f9fafb;
+}
+.chat-message {
+  margin-bottom: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  max-width: 70%;
+}
+.chat-message.user {
+  background: var(--primary);
+  color: #fff;
+  margin-left: auto;
+}
+.chat-message.ai {
+  background: #e5e7eb;
+}
+.chat-input {
+  display: flex;
+  gap: 0.5rem;
+}
+.chat-input input {
+  flex: 1;
+}
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/static-site/index.html
+++ b/static-site/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GeneticsCare AI</title>
+  <link rel="stylesheet" href="css/app.css" />
+</head>
+<body data-page="home">
+  <header>
+    <div class="header-content">
+      <a href="index.html" class="logo"><img src="assets/logo.svg" alt="GeneticsCare AI logo" />GeneticsCare AI</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="condition.html">Condition</a>
+        <a href="qa.html">Q&amp;A</a>
+        <a href="login.html">Login</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container">
+    <section class="hero">
+      <h1>Welcome to GeneticsCare AI</h1>
+      <p>Your trusted genetics counseling companion.</p>
+      <a href="login.html" class="btn primary">Get Started</a>
+    </section>
+  </main>
+  <footer>
+    <div class="container">
+      <p>&copy; 2024 GeneticsCare AI</p>
+      <span class="disclaimer">This AI tool is not a doctor or nurse. Information provided should be discussed with qualified healthcare professionals.</span>
+    </div>
+  </footer>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/static-site/js/app.js
+++ b/static-site/js/app.js
@@ -1,0 +1,114 @@
+const API_BASE = "/api";
+
+document.addEventListener('DOMContentLoaded', () => {
+  const page = document.body.dataset.page;
+
+  if (page === 'login') {
+    let isLogin = true;
+    const toggleBtn = document.getElementById('toggle-form');
+    const nameGroup = document.getElementById('name-group');
+    const confirmGroup = document.getElementById('confirm-password-group');
+    const title = document.getElementById('form-title');
+    const description = document.getElementById('form-description');
+    const submitBtn = document.getElementById('submit-btn');
+
+    toggleBtn.addEventListener('click', () => {
+      isLogin = !isLogin;
+      title.textContent = isLogin ? 'Welcome back' : 'Create account';
+      description.textContent = isLogin ? 'Sign in to access your genetic health insights' : 'Join us to understand your genetic health better';
+      toggleBtn.textContent = isLogin ? "Don't have an account? Sign up" : "Already have an account? Sign in";
+      nameGroup.style.display = isLogin ? 'none' : 'block';
+      confirmGroup.style.display = isLogin ? 'none' : 'block';
+      submitBtn.textContent = isLogin ? 'Sign In' : 'Create Account';
+    });
+
+    document.getElementById('login-form').addEventListener('submit', (e) => {
+      e.preventDefault();
+      // in real app we'd POST to `${API_BASE}/login`
+      window.location.href = 'index.html';
+    });
+  }
+
+  if (page === 'condition') {
+    const results = {
+      gene: 'BRCA1',
+      variant: 'c.185delAG',
+      classification: 'Pathogenic',
+      condition: 'Hereditary Breast and Ovarian Cancer Syndrome',
+      riskLevel: 'High',
+      description: 'This genetic variant significantly increases the risk of developing breast and ovarian cancers.',
+      implications: [
+        'Increased lifetime risk of breast cancer (60-80%)',
+        'Increased lifetime risk of ovarian cancer (20-40%)',
+        'Earlier onset of cancer is possible',
+        'Family members may also be at risk'
+      ],
+      recommendations: [
+        'Enhanced screening starting at age 25',
+        'Consider preventive measures (discussed with healthcare team)',
+        'Genetic counseling for family members',
+        'Regular monitoring and checkups'
+      ],
+      resources: [
+        'National Cancer Institute Guidelines',
+        'BRCA Support Groups',
+        'Preventive Care Options',
+        'Family Testing Information'
+      ]
+    };
+
+    document.getElementById('condition-name').textContent = results.condition;
+    document.getElementById('gene-variant').textContent = `Gene: ${results.gene} | Variant: ${results.variant}`;
+    document.getElementById('classification').textContent = results.classification;
+    document.getElementById('description').textContent = results.description;
+
+    const implicationsList = document.getElementById('implications');
+    results.implications.forEach(text => {
+      const li = document.createElement('li');
+      li.textContent = text;
+      implicationsList.appendChild(li);
+    });
+
+    const recommendationsList = document.getElementById('recommendations');
+    results.recommendations.forEach(text => {
+      const li = document.createElement('li');
+      li.textContent = text;
+      recommendationsList.appendChild(li);
+    });
+
+    const resourcesList = document.getElementById('resources');
+    results.resources.forEach(text => {
+      const li = document.createElement('li');
+      li.textContent = text;
+      resourcesList.appendChild(li);
+    });
+
+    document.getElementById('go-to-qa').addEventListener('click', () => {
+      window.location.href = 'qa.html';
+    });
+  }
+
+  if (page === 'qa') {
+    const chatList = document.getElementById('chat-messages');
+    const input = document.getElementById('chat-input');
+    const sendBtn = document.getElementById('send-btn');
+
+    const addMessage = (content, sender = 'user') => {
+      const div = document.createElement('div');
+      div.className = `chat-message ${sender}`;
+      div.textContent = content;
+      chatList.appendChild(div);
+      chatList.scrollTop = chatList.scrollHeight;
+    };
+
+    sendBtn.addEventListener('click', () => {
+      const text = input.value.trim();
+      if (!text) return;
+      addMessage(text, 'user');
+      input.value = '';
+      setTimeout(() => {
+        addMessage('Thanks for your question. This is a demo response based on your BRCA1 results.', 'ai');
+      }, 1000);
+    });
+  }
+});

--- a/static-site/login.html
+++ b/static-site/login.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Login - GeneticsCare AI</title>
+  <link rel="stylesheet" href="css/app.css" />
+</head>
+<body data-page="login">
+  <header>
+    <div class="header-content">
+      <a href="index.html" class="logo"><img src="assets/logo.svg" alt="GeneticsCare AI logo" />GeneticsCare AI</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="condition.html">Condition</a>
+        <a href="qa.html">Q&amp;A</a>
+        <a href="login.html">Login</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container narrow">
+    <div class="card">
+      <h2 id="form-title">Welcome back</h2>
+      <p id="form-description">Sign in to access your genetic health insights</p>
+      <form id="login-form">
+        <div id="name-group" style="display:none">
+          <label for="name">Full Name</label>
+          <input type="text" id="name" name="name" />
+        </div>
+        <div>
+          <label for="email">Email</label>
+          <input type="email" id="email" name="email" required />
+        </div>
+        <div>
+          <label for="password">Password</label>
+          <input type="password" id="password" name="password" required />
+        </div>
+        <div id="confirm-password-group" style="display:none">
+          <label for="confirm">Confirm Password</label>
+          <input type="password" id="confirm" name="confirm" />
+        </div>
+        <div class="actions">
+          <button type="submit" id="submit-btn" class="btn primary">Sign In</button>
+        </div>
+      </form>
+      <div class="actions">
+        <button id="toggle-form" class="link">Don't have an account? Sign up</button>
+      </div>
+    </div>
+  </main>
+  <footer>
+    <div class="container">
+      <p>&copy; 2024 GeneticsCare AI</p>
+      <span class="disclaimer">This AI tool is not a doctor or nurse. Information provided should be discussed with qualified healthcare professionals.</span>
+    </div>
+  </footer>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/static-site/notfound.html
+++ b/static-site/notfound.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Page Not Found - GeneticsCare AI</title>
+  <link rel="stylesheet" href="css/app.css" />
+</head>
+<body data-page="notfound">
+  <header>
+    <div class="header-content">
+      <a href="index.html" class="logo"><img src="assets/logo.svg" alt="GeneticsCare AI logo" />GeneticsCare AI</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="condition.html">Condition</a>
+        <a href="qa.html">Q&amp;A</a>
+        <a href="login.html">Login</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container">
+    <div class="card" style="text-align:center">
+      <h1>404</h1>
+      <p>Oops! Page not found.</p>
+      <a href="index.html" class="btn primary">Return to Home</a>
+    </div>
+  </main>
+  <footer>
+    <div class="container">
+      <p>&copy; 2024 GeneticsCare AI</p>
+      <span class="disclaimer">This AI tool is not a doctor or nurse. Information provided should be discussed with qualified healthcare professionals.</span>
+    </div>
+  </footer>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/static-site/qa.html
+++ b/static-site/qa.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Q&amp;A - GeneticsCare AI</title>
+  <link rel="stylesheet" href="css/app.css" />
+</head>
+<body data-page="qa">
+  <header>
+    <div class="header-content">
+      <a href="index.html" class="logo"><img src="assets/logo.svg" alt="GeneticsCare AI logo" />GeneticsCare AI</a>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="condition.html">Condition</a>
+        <a href="qa.html">Q&amp;A</a>
+        <a href="login.html">Login</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container">
+    <section class="card chat-card">
+      <div id="chat-messages" class="chat-area" aria-live="polite"></div>
+      <div class="chat-input">
+        <label for="chat-input" class="visually-hidden">Ask a question</label>
+        <input id="chat-input" type="text" placeholder="Type your question" />
+        <button id="send-btn" class="btn primary" aria-label="Send">Send</button>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <div class="container">
+      <p>&copy; 2024 GeneticsCare AI</p>
+      <span class="disclaimer">This AI tool is not a doctor or nurse. Information provided should be discussed with qualified healthcare professionals.</span>
+    </div>
+  </footer>
+  <script src="js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `static-site/` with landing, login, condition results, Q&A, and 404 pages
- share styling and common header/footer via `css/app.css`
- implement simple interactions and demo data in `js/app.js`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898e1d224188331869c800164833398